### PR TITLE
Fixed backref name of the groups_user join table.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed backref name of the groups_user join table.
+  [phgross]
 
 
 1.0.1 (2013-12-15)

--- a/opengever/ogds/models/group.py
+++ b/opengever/ogds/models/group.py
@@ -25,7 +25,7 @@ class Group(BASE):
     title = Column(String(50))
 
     users = relation(User, secondary=groups_users,
-                     backref=backref('group_users'))
+                     backref=backref('groups'))
 
     def __init__(self, groupid, **kwargs):
         self.groupid = groupid


### PR DESCRIPTION
The early name `group_users` wrongly suggest that it would return users, but it returns groups.

/cc @lukasgraf @senny 
