### PR TITLE
Added inbox representation

### DIFF
--- a/opengever/ogds/models/inbox.py
+++ b/opengever/ogds/models/inbox.py
@@ -1,0 +1,13 @@
+class Inbox(object):
+
+    def __init__(self, org_unit):
+        self._org_unit = org_unit
+
+    def id(self):
+        return 'inbox:{0}'.format(self._org_unit.id())
+
+    def __repr__(self):
+        return '<Inbox %s>' % self.id()
+
+    def assigned_users(self):
+        return self._org_unit.inbox_group().users

--- a/opengever/ogds/models/org_unit.py
+++ b/opengever/ogds/models/org_unit.py
@@ -1,3 +1,6 @@
+from opengever.ogds.models.inbox import Inbox
+
+
 class OrgUnit(object):
 
     def __init__(self, client):
@@ -15,8 +18,14 @@ class OrgUnit(object):
     def public_url(self):
         return self._client.public_url
 
+    def inbox_group(self):
+        return self._client.inbox_group
+
     def assigned_users(self):
         return self._client.assigned_users()
 
     def assign_to_admin_unit(self, admin_unit):
         admin_unit.org_units.append(self._client)
+
+    def inbox(self):
+        return Inbox(self)

--- a/opengever/ogds/models/tests/test_inbox.py
+++ b/opengever/ogds/models/tests/test_inbox.py
@@ -1,0 +1,53 @@
+from opengever.ogds.models.client import Client
+from opengever.ogds.models.group import Group
+from opengever.ogds.models.org_unit import OrgUnit
+from opengever.ogds.models.inbox import Inbox
+from opengever.ogds.models.testing import DATABASE_LAYER
+from opengever.ogds.models.user import User
+import unittest2
+
+
+class TestInbox(unittest2.TestCase):
+
+    layer = DATABASE_LAYER
+
+    @property
+    def session(self):
+        return self.layer.session
+
+    def setUp(self):
+        super(TestInbox, self).setUp()
+        self.john = User('john')
+        self.hugo = User('hugo')
+        self.peter = User('peter')
+        self.session.add(self.john)
+        self.session.add(self.hugo)
+        self.session.add(self.peter)
+
+        members = Group('members', users=[self.john, self.hugo, self.peter])
+        self.session.add(members)
+
+        inbox_members = Group('members', users=[self.john, self.peter])
+        self.session.add(inbox_members)
+
+        client_a = Client('clienta',
+                          title='Client A',
+                          public_url='http://localhost',
+                          users_group=members,
+                          inbox_group=inbox_members)
+
+        org_unit = OrgUnit(client_a)
+
+        self.session.add(client_a)
+
+        self.inbox = Inbox(org_unit)
+
+    def test_id_is_clients_id_prefixed_with_inbox_and_point(self):
+        self.assertEquals('inbox:clienta', self.inbox.id())
+
+    def test_representation(self):
+        self.assertEquals('<Inbox inbox:clienta>', self.inbox.__repr__())
+
+    def test_assigned_users_list_users_from_clients_inbox_group(self):
+        self.assertEquals([self.john, self.peter],
+                          self.inbox.assigned_users())

--- a/opengever/ogds/models/tests/test_org_unit.py
+++ b/opengever/ogds/models/tests/test_org_unit.py
@@ -55,3 +55,9 @@ class TestOrgUnit(unittest2.TestCase):
     def test_assigned_users_returns_all_users_from_the_clients_usersgroup(self):
         self.assertEquals(
             [self.john, self.hugo], self.org_unit.assigned_users())
+
+    def test_inbox_returns_inbox_according_to_the_org_unit(self):
+        inbox = self.org_unit.inbox()
+
+        self.assertEquals('inbox:clienta', inbox.id())
+        self.assertEquals(self.org_unit, inbox._org_unit)


### PR DESCRIPTION
Added inbox representation to the ogds models.

As we defined here https://github.com/4teamwork/gever/issues/9, every OrgUnit administer one inbox. It makes sense to implement this concept in the models definition as well.

@deiferni 
