### PR TITLE
Reworked AdminUnit and Client Relationship.

### DIFF
--- a/opengever/ogds/models/admin_unit.py
+++ b/opengever/ogds/models/admin_unit.py
@@ -31,10 +31,9 @@ class AdminUnit(BASE):
         return self.title
 
     def assigned_users(self):
-        users = []
+        users = set()
         for org_unit in self.org_units:
-            users += org_unit.assigned_users()
-
+            users.update(org_unit.assigned_users())
         return users
 
     @property

--- a/opengever/ogds/models/tests/test_admin_unit.py
+++ b/opengever/ogds/models/tests/test_admin_unit.py
@@ -72,3 +72,7 @@ class TestAdminUnit(unittest2.TestCase):
     def test_org_unit_setter_updates_client_relations(self):
         self.admin_unit.org_units = [self.org_unit_a]
         self.assertEqual([self.client_a], self.admin_unit.clients)
+
+    def test_assigned_users_return_assigned_users_of_all_orgunits(self):
+        self.assertItemsEqual([self.hugo, self.peter, self.john],
+                              self.admin_unit.assigned_users())


### PR DESCRIPTION
Renamed client relationship and define org_units getter and setter instead.

This solves the issue that the `org_units` property on a AdminUnit object returns a liest of clients instead of a list of orgunits.

@deiferni please take a look.
