### PR TITLE
Moved decision if inbox group agency is active, to the org unit itself.

### DIFF
--- a/opengever/ogds/models/org_unit.py
+++ b/opengever/ogds/models/org_unit.py
@@ -48,11 +48,22 @@ class OrgUnit(object):
     def admin_unit(self):
         return self._client.admin_unit
 
+    @property
+    def is_inboxgroup_agency_active(self):
+        """The inbox group acengy is only activated in a multi-orgunit
+        setup."""
+
+        return True
+
 
 class LoneOrgUnit(OrgUnit):
     """Handles special cases when only one OrgUnit is available in the whole
     system.
-
     """
+
     def prefix_label(self, label):
         return label
+
+    @property
+    def is_inboxgroup_agency_active(self):
+        return False

--- a/opengever/ogds/models/tests/test_org_unit.py
+++ b/opengever/ogds/models/tests/test_org_unit.py
@@ -91,3 +91,14 @@ class TestOrgUnit(unittest2.TestCase):
         self.session.commit()
 
         self.assertEqual(admin_unit, self.org_unit.admin_unit)
+
+    def test_inboxgroup_agency_is_inactive_for_lone_org_unit(self):
+        org_unit = self.service.fetch_org_unit('clienta')
+
+        self.assertFalse(org_unit.is_inboxgroup_agency_active)
+
+    def test_inboxgroup_agency_is_active_for_multiple_org_units(self):
+        self.session.add(Client('clientb'))
+
+        org_unit = self.service.fetch_org_unit('clienta')
+        self.assertTrue(org_unit.is_inboxgroup_agency_active)


### PR DESCRIPTION
So we it's very easy to handle the special use case when only one org_unit is available in the whole system.

@deiferni 
