### PR TITLE
Add `abbreviation` column to admin_unit table.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- Add `abbreviation` column to admin_unit table.
+  [phgross]
+
 - Add OGDSService which provides an entry point to query data.
   [phgross, deiferni]
 

--- a/opengever/ogds/models/admin_unit.py
+++ b/opengever/ogds/models/admin_unit.py
@@ -15,6 +15,7 @@ class AdminUnit(BASE):
     ip_address = Column(String(50), nullable=False)
     site_url = Column(String(100), nullable=False)
     public_url = Column(String(100), nullable=False)
+    abbreviation = Column(String(50), nullable=False)
 
     org_units = relationship("OrgUnit", backref="admin_unit")
 

--- a/opengever/ogds/models/tests/builders.py
+++ b/opengever/ogds/models/tests/builders.py
@@ -63,6 +63,7 @@ class AdminUnitBuilder(SqlObjectBuilder):
         self.arguments['ip_address'] = '1.2.3.4'
         self.arguments['site_url'] = 'http://example.com'
         self.arguments['public_url'] = 'http://example.com/public'
+        self.arguments['abbreviation'] = 'Client1'
         self.org_unit = None
 
     def wrapping_org_unit(self, org_unit):


### PR DESCRIPTION
Used in the reference number generation by `opengever.core`.

The corresponding upgradestep is included in the PR in `opengever.core`

@deiferni please have a look ... 
