### PR TITLE
Harmonize column lengths of groupid and userid columns.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Harmonize column lengths of groupid and userid columns.
+  [phgross]
 
 
 2.0.0 (2014-10-24)

--- a/opengever/ogds/models/group.py
+++ b/opengever/ogds/models/group.py
@@ -8,9 +8,9 @@ from sqlalchemy.orm import backref, relation
 # association table
 groups_users = Table(
     'groups_users', BASE.metadata,
-    Column('groupid', String(50),
+    Column('groupid', String(255),
            ForeignKey('groups.groupid'), primary_key=True),
-    Column('userid', String(30),
+    Column('userid', String(255),
            ForeignKey('users.userid'), primary_key=True),
     )
 

--- a/opengever/ogds/models/org_unit.py
+++ b/opengever/ogds/models/org_unit.py
@@ -36,7 +36,7 @@ class OrgUnit(BASE):
     enabled = Column(Boolean(), default=True)
 
     # formerly 'group'
-    users_group_id = Column(String(30),
+    users_group_id = Column(String(255),
                             ForeignKey('groups.groupid'),
                             nullable=False)
     users_group = relationship(
@@ -44,7 +44,7 @@ class OrgUnit(BASE):
         backref='org_unit_group',
         primaryjoin=users_group_id == Group.groupid)
 
-    inbox_group_id = Column(String(30),
+    inbox_group_id = Column(String(255),
                             ForeignKey('groups.groupid'),
                             nullable=False)
     inbox_group = relationship(


### PR DESCRIPTION
Right now the `user` resp. the `group` table defines an other column size than the foreign_key tables does.

This PR solves this issue. The corresponding upgradestep is implemented in the `opengever.core` package.

@deiferni please have a look ... 
