### PR TITLE
Move extend_query_with_textfilter functionality to a separte method.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Move extend_query_with_textfilter functionality to a separte method.
+  [phgross]
 
 
 2.1.0 (2015-03-12)

--- a/opengever/ogds/models/query.py
+++ b/opengever/ogds/models/query.py
@@ -18,22 +18,24 @@ class BaseQuery(Query):
     def by_searchable_text(self, text_filters=[]):
         """Extends the given `query` with text_filters, a list of text snippets.
         """
+        fields = [self._attribute(f) for f in self.searchable_fields]
+        return extend_query_with_textfilter(self, fields, text_filters)
 
-        query = self
 
-        if text_filters:
-            for word in text_filters:
-                term = self._add_wildcards(word)
-                fields = [self._attribute(f) for f in self.searchable_fields]
-                query = query.filter(
-                    or_(*[field.like(term) for field in fields]))
+def extend_query_with_textfilter(query, fields, text_filters):
+    if text_filters:
+        for word in text_filters:
+            term = _add_wildcards(word)
+            query = query.filter(
+                or_(*[field.like(term) for field in fields]))
 
-        return query
+    return query
 
-    def _add_wildcards(self, word):
-        """Add leading and trailing wildcards and replace asterisks with
-        wildcards.
-        """
 
-        word = word.strip('*').replace('*', '%')
-        return u'%{0}%'.format(word)
+def _add_wildcards(word):
+    """Add leading and trailing wildcards and replace asterisks with
+    wildcards.
+    """
+
+    word = word.strip('*').replace('*', '%')
+    return u'%{0}%'.format(word)


### PR DESCRIPTION
This method helps to extend an custom query with a textfilter, used for example from the gever  notification_center.

@deiferni please have a look