### PR TITLE
Adapt imports for SQLAlchemy 1.x compatibility.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,11 @@ Changelog
 =========
 
 
-2.2.1 (unreleased)
+2.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Adapt imports for SQLAlchemy 1.x.
+  [lgraf]
 
 
 2.2.0 (2015-06-01)

--- a/opengever/ogds/models/query.py
+++ b/opengever/ogds/models/query.py
@@ -1,6 +1,6 @@
 from sqlalchemy import or_
 from sqlalchemy.orm import Query
-from sqlalchemy.orm.util import _entity_descriptor
+from sqlalchemy.orm.base import _entity_descriptor
 
 
 class BaseQuery(Query):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '2.2.1.dev0'
+version = '2.3.0.dev0'
 maintainer = '4teamwork AG'
 
 tests_require = [


### PR DESCRIPTION
This import needs to be changed for compatibility with SQLAlchemy 1.x.