### PR TITLE
Add `active` column to `Group` model.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- Add `active` column to `Group` model.
+  (Corresponding upgrade-step is in opengever.ogds.base:default)
+  [lgraf]
+
 - Adapt imports for SQLAlchemy 1.x.
   [lgraf]
 

--- a/opengever/ogds/models/group.py
+++ b/opengever/ogds/models/group.py
@@ -2,9 +2,12 @@ from opengever.ogds.models import BASE
 from opengever.ogds.models import GROUP_ID_LENGTH
 from opengever.ogds.models import USER_ID_LENGTH
 from opengever.ogds.models.user import User
-from sqlalchemy import Column, String, Table
+from sqlalchemy import Column
 from sqlalchemy import ForeignKey
-from sqlalchemy.orm import backref, relation
+from sqlalchemy import String
+from sqlalchemy import Table
+from sqlalchemy.orm import backref
+from sqlalchemy.orm import relation
 
 
 # association table
@@ -14,7 +17,7 @@ groups_users = Table(
            ForeignKey('groups.groupid'), primary_key=True),
     Column('userid', String(USER_ID_LENGTH),
            ForeignKey('users.userid'), primary_key=True),
-    )
+)
 
 
 class Group(BASE):

--- a/opengever/ogds/models/group.py
+++ b/opengever/ogds/models/group.py
@@ -3,6 +3,7 @@ from opengever.ogds.models import GROUP_ID_LENGTH
 from opengever.ogds.models import USER_ID_LENGTH
 from opengever.ogds.models.user import User
 from sqlalchemy import Column
+from sqlalchemy import Boolean
 from sqlalchemy import ForeignKey
 from sqlalchemy import String
 from sqlalchemy import Table
@@ -27,6 +28,7 @@ class Group(BASE):
     __tablename__ = 'groups'
 
     groupid = Column(String(GROUP_ID_LENGTH), primary_key=True)
+    active = Column(Boolean, default=True)
     title = Column(String(50))
 
     users = relation(User, secondary=groups_users,

--- a/opengever/ogds/models/user.py
+++ b/opengever/ogds/models/user.py
@@ -4,7 +4,10 @@ from opengever.ogds.models import FIRSTNAME_LENGTH
 from opengever.ogds.models import LASTNAME_LENGTH
 from opengever.ogds.models import USER_ID_LENGTH
 from opengever.ogds.models.query import BaseQuery
-from sqlalchemy import Column, String, Boolean, Text
+from sqlalchemy import Boolean
+from sqlalchemy import Column
+from sqlalchemy import String
+from sqlalchemy import Text
 
 
 class UserQuery(BaseQuery):


### PR DESCRIPTION
Adds a column `active` to the OGDS `Group` models that allows us to flag groups that have been removed from LDAP as inactive.

The corresponding Upgrade-Step is in `opengever.ogds.base:default`.