### PR TITLE
Add an `UnicodeCoercingText` TypeDecorator for the `Text` type

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,14 @@ Changelog
 2.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add an `UnicodeCoercingText` TypeDecorator for the `Text` type that
+  always returns unicode for values fetched from the DB. This allows
+  us to have a guarantee to always receive unicode for `Text` types,
+  even when using Oracle as the backend.
+  The effect of this TypeDecorator should be the same as the cxOracle
+  dialect option `coerce_to_unicode`, which unfortunately only affects
+  `String` columns.
+  [lgraf]
 
 
 2.3.0 (2015-08-03)

--- a/opengever/ogds/models/types.py
+++ b/opengever/ogds/models/types.py
@@ -1,0 +1,27 @@
+from sqlalchemy import types
+
+
+def safe_unicode(value):
+    if isinstance(value, str):
+        return value.decode('utf-8')
+    assert isinstance(value, unicode)
+    return value
+
+
+class UnicodeCoercingText(types.TypeDecorator):
+    """TypeDecorator for the `Text` type that always returns unicode for
+    values fetched from the DB. This allows us to have a guarantee to always
+    receive unicode for `Text` types, even when using Oracle as the backend.
+
+    The effect of this TypeDecorator should be the same as the cxOracle
+    dialect option `coerce_to_unicode`, which unfortunately only affects
+    `String` columns.
+    """
+
+    impl = types.Text
+    python_type = unicode
+
+    def process_result_value(self, value, dialect):
+        if value is not None:
+            value = safe_unicode(value)
+        return value

--- a/opengever/ogds/models/user.py
+++ b/opengever/ogds/models/user.py
@@ -4,10 +4,10 @@ from opengever.ogds.models import FIRSTNAME_LENGTH
 from opengever.ogds.models import LASTNAME_LENGTH
 from opengever.ogds.models import USER_ID_LENGTH
 from opengever.ogds.models.query import BaseQuery
+from opengever.ogds.models.types import UnicodeCoercingText
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import String
-from sqlalchemy import Text
 
 
 class UserQuery(BaseQuery):
@@ -41,7 +41,7 @@ class User(BASE):
     phone_mobile = Column(String(30))
 
     salutation = Column(String(30))
-    description = Column(Text())
+    description = Column(UnicodeCoercingText())
     address1 = Column(String(100))
     address2 = Column(String(100))
     zip_code = Column(String(10))


### PR DESCRIPTION
Add an `UnicodeCoercingText` TypeDecorator for the `Text` type that always returns unicode for values fetched from the DB.

This allows us to have a guarantee to always receive unicode for `Text` types, even when using Oracle as the backend.

The effect of this TypeDecorator should be the same as the [cxOracle dialect option `coerce_to_unicode`](http://docs.sqlalchemy.org/en/latest/dialects/oracle.html#unicode), which unfortunately only affects `String` columns.

@phgross @deiferni 