### PR TITLE
Optimize assigned_users of an AdminUnit

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Optimize performance of `assigned_users()` method of an `AdminUnit`.
+  [buchi]
 
 
 2.4.0 (2015-12-11)

--- a/opengever/ogds/models/admin_unit.py
+++ b/opengever/ogds/models/admin_unit.py
@@ -1,6 +1,9 @@
 from opengever.ogds.models import BASE
 from opengever.ogds.models import UNIT_ID_LENGTH
 from opengever.ogds.models import UNIT_TITLE_LENGTH
+from opengever.ogds.models.group import groups_users
+from opengever.ogds.models.org_unit import OrgUnit
+from opengever.ogds.models.user import User
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import String
@@ -46,10 +49,10 @@ class AdminUnit(BASE):
         return self.title or u''
 
     def assigned_users(self):
-        users = set()
-        for org_unit in self.org_units:
-            users.update(org_unit.assigned_users())
-        return users
+        return self.session.query(User).filter(
+            User.userid == groups_users.columns.userid).filter(
+            groups_users.columns.groupid == OrgUnit.users_group_id).filter(
+            OrgUnit.admin_unit_id == self.unit_id).all()
 
     def prefix_label(self, label):
         return u'{0} / {1}'.format(self.label(), label)

--- a/opengever/ogds/models/tests/test_admin_unit.py
+++ b/opengever/ogds/models/tests/test_admin_unit.py
@@ -11,6 +11,7 @@ class TestAdminUnit(OGDSTestCase):
         self.john = create(Builder('ogds_user').id('john'))
         self.hugo = create(Builder('ogds_user').id('hugo'))
         self.peter = create(Builder('ogds_user').id('peter'))
+        self.jack = create(Builder('ogds_user').id('jack'))
 
         self.members_a = create(Builder('ogds_group')
                                 .id('members_a')
@@ -19,6 +20,10 @@ class TestAdminUnit(OGDSTestCase):
         self.members_b = create(Builder('ogds_group')
                                 .id('members_b')
                                 .having(users=[self.peter, self.hugo]))
+
+        self.members_c = create(Builder('ogds_group')
+                                .id('members_c')
+                                .having(users=[self.jack]))
 
         self.org_unit_a = create(Builder('org_unit')
                                  .id('unita')
@@ -31,6 +36,12 @@ class TestAdminUnit(OGDSTestCase):
                                  .having(title='Unit B',
                                          users_group=self.members_b,
                                          admin_unit_id='canton'))
+
+        self.org_unit_c = create(Builder('org_unit')
+                                 .id('unitc')
+                                 .having(title='Unit C',
+                                         users_group=self.members_c,
+                                         admin_unit_id='other'))
 
         self.admin_unit = create(Builder('admin_unit')
                                  .id('canton')


### PR DESCRIPTION
Get assigned users with a single query using joins instead of querying for
each OrgUnit's assigned users.
Also add a user in test setup that does not belong to the tested AdminUnit and
should not be returned by assigned_users().

Before optimization the method returned a set. Is there any reason for that beside avoiding duplicates?
If yes, a cast to set has to be added.