### PR TITLE
Add assigned_groups method for the OGDSService.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 2.4.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add assigned_groups method for the OGDSService.
+  It returns all assigned groups for the given userid.
+  [elioschmutz]
 
 
 2.4.2 (2016-03-17)

--- a/opengever/ogds/models/service.py
+++ b/opengever/ogds/models/service.py
@@ -38,6 +38,11 @@ class OGDSService(object):
         query = query.filter(OrgUnit.enabled==True)
         return query.all()
 
+    def assigned_groups(self, userid):
+        query = self.session.query(Group).join(Group.users)
+        query = query.filter(User.userid == userid)
+        return query.all()
+
     def fetch_org_unit(self, unit_id):
         return self._query_org_units().get(unit_id)
 

--- a/opengever/ogds/models/tests/test_service.py
+++ b/opengever/ogds/models/tests/test_service.py
@@ -148,6 +148,27 @@ class TestServiceOrgUnitMethods(OGDSTestCase):
 
         self.assertSequenceEqual([self.unit_a, self.unit_c], units)
 
+    def test_assigned_groups_returns_empty_list_if_no_groups_are_assigned(self):
+        create(Builder('ogds_user').id('chuck.norris'))
+        groups = self.service.assigned_groups('chuck.norris')
+
+        self.assertEqual([], groups)
+
+    def test_assigned_groups_returns_a_list_of_multiple_groups(self):
+        chuck = create(Builder('ogds_user').id('chuck.norris'))
+
+        administrators = create(Builder('ogds_group')
+                                .id('administrators')
+                                .having(users=[chuck]))
+
+        editors = create(Builder('ogds_group')
+                              .id('editors')
+                              .having(users=[chuck]))
+
+        groups = self.service.assigned_groups('chuck.norris')
+
+        self.assertSequenceEqual([administrators, editors], groups)
+
     def test_all_org_units_returns_list_of_all_orgunits(self):
         units = self.service.all_org_units()
 


### PR DESCRIPTION
Adds a missing api method: ``assigned_groups``

It returns all assigned groups for the given userid.

@deiferni Pls take a look at my query...