### PR TITLE
Handle missing OGDS user in AdminUnit.is_user_assigned():

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.4.2 (unreleased)
 ------------------
 
+- Handle missing OGDS user in AdminUnit.is_user_assigned().
+  [lgraf]
+
 - Add optimized method for checking if a user is assigned to an `AdminUnit`.
   [buchi]
 

--- a/opengever/ogds/models/admin_unit.py
+++ b/opengever/ogds/models/admin_unit.py
@@ -56,6 +56,10 @@ class AdminUnit(BASE):
             OrgUnit.admin_unit_id == self.unit_id).all()
 
     def is_user_assigned(self, user):
+        if user is None:
+            # There might not be a corresponding OGDS user
+            return False
+
         return self.session.query(exists().where(
             OrgUnit.admin_unit_id == self.unit_id).where(
             OrgUnit.users_group_id == groups_users.columns.groupid).where(

--- a/opengever/ogds/models/tests/test_admin_unit.py
+++ b/opengever/ogds/models/tests/test_admin_unit.py
@@ -85,6 +85,9 @@ class TestAdminUnit(OGDSTestCase):
     def test_is_user_assigned_to_admin_unit_returns_false(self):
         self.assertFalse(self.admin_unit.is_user_assigned(self.jack))
 
+    def test_is_user_assigned_handles_missing_ogds_user(self):
+        self.assertFalse(self.admin_unit.is_user_assigned(None))
+
     def test_prefix_label(self):
         self.assertEqual(u'Canton Unit / foo',
                          self.admin_unit.prefix_label('foo'))


### PR DESCRIPTION
Handle missing OGDS user in `AdminUnit.is_user_assigned()` after it has been optimized in #39.

`user` might be `None` for Plone users that don't have a corresponding OGDS user (because they're not an LDAP user, and LDAP is the only type of user source that gets synced to OGDS).

The previous implementation in essence did `if user in list_of_users`, which will have evaluated to `False` for cases where `user` was `None`.