### PR TITLE
Made extend_query_with_textfilter case insensitive.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Made extend_query_with_textfilter case insensitive.
+  [phgross]
 
 
 2.5.0 (2016-05-02)

--- a/opengever/ogds/models/query.py
+++ b/opengever/ogds/models/query.py
@@ -27,7 +27,7 @@ def extend_query_with_textfilter(query, fields, text_filters):
         for word in text_filters:
             term = _add_wildcards(word)
             query = query.filter(
-                or_(*[field.like(term) for field in fields]))
+                or_(*[field.ilike(term) for field in fields]))
 
     return query
 

--- a/opengever/ogds/models/testing.py
+++ b/opengever/ogds/models/testing.py
@@ -39,6 +39,10 @@ class DatabaseLayer(Layer):
         if not self._engine:
             self._engine = create_engine('sqlite://')
 
+            # make like case sensitive, to have the same conditions as we have
+            # with PostgreSQL in production
+            self._engine.execute('PRAGMA case_sensitive_like = ON')
+
             BASE.metadata.bind = self._engine
             BASE.metadata.create_all()
 

--- a/opengever/ogds/models/tests/test_query.py
+++ b/opengever/ogds/models/tests/test_query.py
@@ -70,6 +70,11 @@ class TestUserQuery(unittest2.TestCase):
             [self.jason, self.hugo],
             User.query.by_searchable_text(['Br']).all())
 
+    def test_by_searchable_text_is_case_insensitive(self):
+        self.assertEqual(
+            [self.james],
+            User.query.by_searchable_text(['james']).all())
+
     def test_by_searchable_handles_multiple_text_snippets(self):
         self.assertEqual(
             [self.jason, self.hugo],


### PR DESCRIPTION
Besides I've changed the `case_sensitive_like` setting for the test database, to make sure that we have the same conditions as we have with PostgreSQL in production.

@deiferni 