### PR TITLE
Make sure extend_query_with_textfilter works also on Integer columns.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.5.1 (unreleased)
 ------------------
 
+- Make sure extend_query_with_textfilter works also on Integer columns.
+  [phgross]
+
 - Made extend_query_with_textfilter case insensitive.
   [phgross]
 

--- a/opengever/ogds/models/query.py
+++ b/opengever/ogds/models/query.py
@@ -1,6 +1,8 @@
 from sqlalchemy import or_
+from sqlalchemy import String
 from sqlalchemy.orm import Query
 from sqlalchemy.orm.base import _entity_descriptor
+from sqlalchemy.sql.expression import cast
 
 
 class BaseQuery(Query):
@@ -27,7 +29,7 @@ def extend_query_with_textfilter(query, fields, text_filters):
         for word in text_filters:
             term = _add_wildcards(word)
             query = query.filter(
-                or_(*[field.ilike(term) for field in fields]))
+                or_(*[cast(field, String).ilike(term) for field in fields]))
 
     return query
 


### PR DESCRIPTION
See http://stackoverflow.com/questions/12643646/sqlalchemy-postgresql-where-int-string.

Used by https://github.com/4teamwork/opengever.core/pull/2172

@deiferni 