### PR TITLE
Let sql testing builders commit the transaction.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Let sql testing builders commit the transaction. [jone]
 
 
 2.6.0 (2016-10-18)

--- a/opengever/ogds/models/tests/builders.py
+++ b/opengever/ogds/models/tests/builders.py
@@ -5,6 +5,7 @@ from opengever.ogds.models.admin_unit import AdminUnit
 from opengever.ogds.models.group import Group
 from opengever.ogds.models.org_unit import OrgUnit
 from opengever.ogds.models.user import User
+import transaction
 
 
 class SqlObjectBuilder(object):
@@ -39,6 +40,9 @@ class SqlObjectBuilder(object):
 
     def persist(self):
         if self.session.auto_commit:
+            transaction.commit()
+
+        if getattr(self.session, 'auto_flush', False):
             self.db_session.flush()
 
     def add_object_to_session(self, obj):


### PR DESCRIPTION
Let the SQL builders commit after create when auto_commit is enabled.
This is important in order to move towards PostgreSQL tests.

The non-Plone memory tests still need the session flush feature, so we introduce the auto_flush builder option.

This change needs the counterpart https://github.com/4teamwork/opengever.core/pull/2745