### PR TITLE
Fixes AdminUnits is_user_assigned query for oracle backends.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixes AdminUnits is_user_assigned query for oracle backends. [phgross]
 
 
 2.6.1 (2017-03-24)

--- a/opengever/ogds/models/admin_unit.py
+++ b/opengever/ogds/models/admin_unit.py
@@ -6,8 +6,9 @@ from opengever.ogds.models.org_unit import OrgUnit
 from opengever.ogds.models.user import User
 from sqlalchemy import Boolean
 from sqlalchemy import Column
-from sqlalchemy import String
 from sqlalchemy import exists
+from sqlalchemy import literal
+from sqlalchemy import String
 from sqlalchemy.orm import relationship
 
 
@@ -60,7 +61,7 @@ class AdminUnit(BASE):
             # There might not be a corresponding OGDS user
             return False
 
-        return self.session.query(exists().where(
+        return self.session.query(literal(True)).filter(exists().where(
             OrgUnit.admin_unit_id == self.unit_id).where(
             OrgUnit.users_group_id == groups_users.columns.groupid).where(
             groups_users.columns.userid == user.userid)).scalar()

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -1,12 +1,9 @@
 [buildout]
 extends =
-    http://dist.plone.org/release/4.3-latest/versions.cfg
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
     https://raw.githubusercontent.com/4teamwork/opengever.core/master/versions.cfg
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-package.cfg
 
-jenkins_python = $PYTHON27
 package-name = opengever.ogds.models
 
 [versions]
 opengever.ogds.models =
-AccessControl = 2.13.10


### PR DESCRIPTION
See the following note in the SQLAlchemy documentation (http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.query.Query.exists):

> Note that some databases such as SQL Server don’t allow an EXISTS expression to be present in the columns clause of a SELECT. To select a simple boolean value based on the exists as a WHERE, use literal():

Oracle seems one of this databases ...