### PR TITLE
Fixes extend_query_with_textfilter for oracle backends, only cast on not string columns.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.6.2 (unreleased)
 ------------------
 
+- Fixes extend_query_with_textfilter for oracle backends, only cast on not string columns. [phgross]
+
 - Fixes AdminUnits is_user_assigned query for oracle backends. [phgross]
 
 

--- a/opengever/ogds/models/query.py
+++ b/opengever/ogds/models/query.py
@@ -28,8 +28,14 @@ def extend_query_with_textfilter(query, fields, text_filters):
     if text_filters:
         for word in text_filters:
             term = _add_wildcards(word)
-            query = query.filter(
-                or_(*[cast(field, String).ilike(term) for field in fields]))
+
+            expressions = []
+            for field in fields:
+                if not issubclass(field.type.python_type, basestring):
+                    field = cast(field, String)
+                expressions.append(field.ilike(term))
+
+            query = query.filter(or_(*expressions))
 
     return query
 


### PR DESCRIPTION
Currently all expressions contain a string cast statement, even if the field is already a string column. This is unnecessary and leads to an issue with oracle backends (see traceback below).  The new implementation ads casting only for not stringy fields.

```
DatabaseError: (cx_Oracle.DatabaseError) ORA-00906: missing left parenthesis
 [SQL: u'SELECT users.userid AS users_userid, users.active AS users_active, users.firstname AS users_firstname, users.lastname AS users_lastname, users.directorate AS users_directorate, users.directorate_abbr AS users_directorate_abbr, users.department AS users_department, users.department_abbr AS users_department_abbr, users.email AS users_email, users.email2 AS users_email2, users.url AS users_url, users.phone_office AS users_phone_office, users.phone_fax AS users_phone_fax, users.phone_mobile AS users_phone_mobile, users.salutation AS users_salutation, users.description AS users_description, users.address1 AS users_address1, users.address2 AS users_address2, users.zip_code AS users_zip_code, users.city AS users_city, users.country AS users_country, users.import_stamp AS users_import_stamp, org_units.unit_id AS org_units_unit_id, org_units.title AS org_units_title, org_units.enabled AS org_units_enabled, org_units.users_group_id AS org_units_users_group_id, org_units.inbox_group_id AS org_units_inbox_group_id, org_units.admin_unit_id AS org_units_admin_unit_id \nFROM org_units JOIN groups ON org_units.users_group_id = groups.groupid JOIN groups_users groups_users_1 ON groups.groupid = groups_users_1.groupid JOIN users ON users.userid = groups_users_1.userid \nWHERE (lower(CAST(org_units.title AS VARCHAR2)) LIKE lower(:param_1) OR lower(CAST(org_units.unit_id AS VARCHAR2)) LIKE lower(:param_2) OR lower(CAST(users.userid AS VARCHAR2)) LIKE lower(:param_3) OR lower(CAST(users.firstname AS VARCHAR2)) LIKE lower(:param_4) OR lower(CAST(users.lastname AS VARCHAR2)) LIKE lower(:param_5) OR lower(CAST(users.email AS VARCHAR2)) LIKE lower(:param_6)) AND users.active = 1 ORDER BY lower(users.lastname) ASC, lower(users.firstname) ASC'] [parameters: {u'param_5': u'%marc%', u'param_4': u'%marc%', u'param_6': u'%marc%', u'param_1': u'%marc%', u'param_3': u'%marc%', u'param_2': u'%marc%'}]
```
