### PR TITLE
Add helper methods and queries for team add and edit forms.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,8 @@ Changelog
 ------------------
 
 - Add helper methods and queries for team add and edit form support. [phgross]
+- Add new model Team. [phgross]
+
 
 2.6.2 (2017-07-11)
 ------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 2.6.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Add helper methods and queries for team add and edit form support. [phgross]
 
 2.6.2 (2017-07-11)
 ------------------

--- a/opengever/ogds/models/group.py
+++ b/opengever/ogds/models/group.py
@@ -1,6 +1,7 @@
 from opengever.ogds.models import BASE
 from opengever.ogds.models import GROUP_ID_LENGTH
 from opengever.ogds.models import USER_ID_LENGTH
+from opengever.ogds.models.query import BaseQuery
 from opengever.ogds.models.team import Team # noqa
 from opengever.ogds.models.user import User
 from sqlalchemy import Boolean
@@ -23,9 +24,17 @@ groups_users = Table(
 )
 
 
+class GroupQuery(BaseQuery):
+
+    searchable_fields = ['groupid', 'title']
+
+
+
 class Group(BASE):
     """Group model, corresponds to a LDAP group
     """
+
+    query_cls = GroupQuery
 
     __tablename__ = 'groups'
 
@@ -54,3 +63,9 @@ class Group(BASE):
         if result is NotImplemented:
             return result
         return not result
+
+    def id(self):
+        return self.groupid
+
+    def label(self):
+        return self.title or self.groupid

--- a/opengever/ogds/models/org_unit.py
+++ b/opengever/ogds/models/org_unit.py
@@ -4,6 +4,7 @@ from opengever.ogds.models import UNIT_ID_LENGTH
 from opengever.ogds.models import UNIT_TITLE_LENGTH
 from opengever.ogds.models.group import Group
 from opengever.ogds.models.inbox import Inbox
+from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
@@ -31,8 +32,16 @@ class LoneOrgUnitStrategy(object):
         return False
 
 
+class OrgUnitQuery(BaseQuery):
+
+    searchable_fields = ['unit_id', 'title']
+
+
 class OrgUnit(BASE):
+
     __tablename__ = 'org_units'
+
+    query_cls = OrgUnitQuery
 
     unit_id = Column(String(UNIT_ID_LENGTH), primary_key=True)
     title = Column(String(UNIT_TITLE_LENGTH))

--- a/opengever/ogds/models/team.py
+++ b/opengever/ogds/models/team.py
@@ -57,3 +57,30 @@ class Team(BASE):
 
     def label(self):
         return u'{} ({})'.format(self.title, self.org_unit.title)
+
+    # TODO: the following methods should be removed when moving
+    # opengever.ogds.models to opengever.core and inherit from
+    # `opengever.base.model.SQLFormSupport` instead.
+
+    def is_editable_by_current_user(self, container):
+        return False
+
+    def is_editable(self):
+        return True
+
+    def get_edit_values(self, fieldnames):
+        values = {}
+        for fieldname in fieldnames:
+            value = getattr(self, fieldname, None)
+            if not value:
+                continue
+
+            values[fieldname] = value
+        return values
+
+    def get_edit_url(self, context):
+        return self.get_url(context, view='edit')
+
+    def update_model(self, data):
+        for key, value in data.items():
+            setattr(self, key, value)


### PR DESCRIPTION
Harmonize models: use basequery class for OrgUnits and Groups and provide `id` and `label` methods, which makes it easier to implement general ways to handle different sql objects. Used for the new OrgUnit and Groups sources.

Add SQLFormSupport methods to Team model, used by add and edit forms. those methods should be removed when moving opengever.ogds.models to opengever.core and inherit from `opengever.base.model.SQLFormSupport` instead. But I'll do the movement in a separate PR.
