### PR TITLE
Fix get_edit_values for teams active flag.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 2.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix get_edit_values for teams active flag. [phgross]
 
 2.7.1 (2017-11-28)
 ------------------

--- a/opengever/ogds/models/team.py
+++ b/opengever/ogds/models/team.py
@@ -69,10 +69,12 @@ class Team(BASE):
         return True
 
     def get_edit_values(self, fieldnames):
+        _marker = object()
+
         values = {}
         for fieldname in fieldnames:
-            value = getattr(self, fieldname, None)
-            if not value:
+            value = getattr(self, fieldname, _marker)
+            if value is _marker:
                 continue
 
             values[fieldname] = value

--- a/opengever/ogds/models/tests/test_team.py
+++ b/opengever/ogds/models/tests/test_team.py
@@ -83,3 +83,16 @@ class TestTeam(OGDSTestCase):
 
         self.assertEquals(team1, Team.query.get_by_actor_id('team:1'))
         self.assertEquals(team2, Team.query.get_by_actor_id('team:2'))
+
+    def test_get_edit_values_handles_boolean_fields(self):
+        team = Team(title=u'\xc4-Team',
+                    group=self.members,
+                    org_unit=self.org_unit,
+                    active=False)
+
+        self.session.add(team)
+        self.session.commit()
+
+        self.assertEquals(
+            {'title': u'\xc4-Team', 'active': False},
+            team.get_edit_values(['title', 'active']))


### PR DESCRIPTION
Handle `False` as a value, otherwise the disabled `active` flag on a team is not returned by the `edit_values` getter.

See https://github.com/4teamwork/opengever.core/pull/3814 and https://github.com/4teamwork/opengever.core/issues/3751 for more information.